### PR TITLE
Add password hashing and trim username/email input on login

### DIFF
--- a/RNApp/app/ddp.js
+++ b/RNApp/app/ddp.js
@@ -1,5 +1,4 @@
 import DDPClient from 'ddp-client';
-import hash from 'hash.js';
 import _ from 'lodash';
 import EJSON from 'ejson';
 import config from './config';
@@ -10,13 +9,6 @@ let ddpClient = new DDPClient(config.ddpConfig);
 /*
  * extend capabilities of ddpClient
  */
-ddpClient.sha256 = (password) => {
-  return {
-    digest: hash.sha256().update(password).digest('hex'),
-    algorithm: "sha-256"
-  };
-};
-
 ddpClient.callPromise = (methodName, params) => {
   params = params || undefined;
   if (params && !_.isArray(params)) {
@@ -53,9 +45,8 @@ ddpClient.subscribePromise = (pubName, params) => {
 ddpClient.signUpWithEmail = (email, password, cb) => {
   let params = {
     email: email,
-    password: ddpClient.sha256(password)
+    password: password
   };
-  console.log(params);
 
   return ddpClient.call('createUser', [params], (err, res) => {
     ddpClient.onAuthResponse(err, res);
@@ -66,9 +57,8 @@ ddpClient.signUpWithEmail = (email, password, cb) => {
 ddpClient.signUpWithUsername = (username, password, cb) => {
   let params = {
     username: username,
-    password: ddpClient.sha256(password)
+    password: password
   };
-  console.log(params);
 
   return ddpClient.call('createUser', [params], (err, res) => {
     ddpClient.onAuthResponse(err, res);
@@ -81,9 +71,8 @@ ddpClient.loginWithEmail = (email, password, cb) => {
     user: {
       email: email
     },
-    password: ddpClient.sha256(password)
+    password: password
   };
-  console.log(params);
 
   return ddpClient.call("login", [params], (err, res) => {
     ddpClient.onAuthResponse(err, res);
@@ -96,9 +85,8 @@ ddpClient.loginWithUsername = (username, password, cb) => {
     user: {
       username: username
     },
-    password: ddpClient.sha256(password)
+    password: password
   };
-  console.log(params);
 
   return ddpClient.call("login", [params], (err, res) => {
     ddpClient.onAuthResponse(err, res);

--- a/RNApp/app/index.js
+++ b/RNApp/app/index.js
@@ -12,7 +12,7 @@ export default class RNApp extends Component {
     this.state = {
       connected: false,
       signedIn: false
-    }
+    };
   }
 
   componentWillMount() {

--- a/RNApp/package.json
+++ b/RNApp/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "ddp-client": "spencercarli/node-ddp-client",
     "ejson": "^2.1.2",
+    "hash.js": "^1.0.3",
     "lodash": "^4.5.0",
     "react-native": "^0.20.0"
   }


### PR DESCRIPTION
Thank you @spencercarli for sharing this boilerplate. I'm likely going to be using this boilerplate so I'd like to give back whenever I come across enhancements that I believe will simplify things for the user and developer. 

Included:
1. Trim for username and email. I found that by using the simulator while developing that I had a habit of hitting `tab` to try to get to the password field. Simulators can't "tab" to the next field but they do add space characters for a tab which makes emails and usernames not to match what the user collection contains. It tripped me up, it could probably trip somebody else up just starting out so I decided to remove any extra whitespace there. If for whatever reason a user accidentally hits spacebar before or after typing their username or email they should authenticate and not have to re-enter.
2. I incorporated the password hashing from [your other repo](http://blog.differential.com/password-hashing-for-meteor-react-native/) because we should always hash before sending it over the wire and since this is a boilerplate, why repeat this step every time you want to start a new project? Thought it would be useful.
3. Semicolons. I'm not a semicolon nazi but I do get visible red hightlights because my editor runs JSHint. I went ahead and appeased some of its complaints about missing semicolons.
