### PR TITLE
Fixing AndroidManifest.xml

### DIFF
--- a/RNApp/android/app/src/main/AndroidManifest.xml
+++ b/RNApp/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
       android:allowBackup="true"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
+      android:name=".MainApplication"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"


### PR DESCRIPTION
I had to set @android:name@ in this file to resolve the following issue:
- Error message in the simulator: **Unfortunately, RNApp has stopped**
- Error message in the Android Monitor: **java.lang.RuntimeException: Unable to start activity ComponentInfo{com.rnapp/com.rnapp.MainActivity}: java.lang.ClassCastException: android.app.Application cannot be cast to com.facebook.react.ReactApplication**
