### PR TITLE
Add ACCESS NETWORK STATE to Android Manifest

### DIFF
--- a/RNApp/android/app/src/main/AndroidManifest.xml
+++ b/RNApp/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <uses-sdk
         android:minSdkVersion="16"


### PR DESCRIPTION
Following what have been discussed here : https://github.com/spencercarli/react-native-meteor-boilerplate/issues/64